### PR TITLE
security: pin docker images to sha256 digests

### DIFF
--- a/build-environment/Dockerfile
+++ b/build-environment/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=alpine:latest
+ARG BASE=alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 
 ##########################################################################
 FROM ${BASE} AS base-config
@@ -29,7 +29,7 @@ WORKDIR /sandbox/input_sandbox
 
 
 ##########################################################################
-FROM alpine:latest AS extracted-musl
+FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4 AS extracted-musl
 ARG CONFIG_DIR=default-config
 WORKDIR /sandbox/resolver
 ADD  https://sca-downloads.s3.amazonaws.com/cli/latest/ScaResolver-musl64.tar.gz /sandbox/resolver
@@ -40,7 +40,7 @@ RUN chmod -R 750 /sandbox/resolver
 
 
 ##########################################################################
-FROM alpine:latest AS extracted-linux
+FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4 AS extracted-linux
 ARG CONFIG_DIR=default-config
 WORKDIR /sandbox/resolver
 ADD https://sca-downloads.s3.amazonaws.com/cli/latest/ScaResolver-linux64.tar.gz /sandbox/resolver
@@ -51,7 +51,7 @@ RUN chmod -R 750 /sandbox/resolver
 
 
 ##########################################################################
-FROM alpine:latest AS cxone-extracted-linux
+FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4 AS cxone-extracted-linux
 WORKDIR /sandbox/cxonecli
 ADD https://github.com/Checkmarx/ast-cli/releases/latest/download/ast-cli_linux_x64.tar.gz /sandbox/cxonecli
 RUN tar -xzf ast-cli_linux_x64.tar.gz && \

--- a/legacy/enhanced-cxflow-scaresolver/Dockerfile
+++ b/legacy/enhanced-cxflow-scaresolver/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:11-al2023-jdk
+FROM amazoncorretto:11-al2023-jdk@sha256:ffd2c9bf16a8ffeaade21ade59c5d1d1865d770d47681e00613c626d023dbd54
 LABEL org.opencontainers.image.source https://github.com/checkmarx-ts/cx-supply-chain-toolkit
 
 

--- a/tests/general-build/Dockerfile
+++ b/tests/general-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:lunar
+FROM ubuntu:lunar@sha256:5a828e28de105c3d7821c4442f0f5d1c52dc16acf4999d5f31a3bc0f03f06edd
 
 RUN apt update
 


### PR DESCRIPTION
Replaces 3 image references across 3 files with @sha256:<digest>
pinned forms. Defends against tag mutation / supply-chain attacks.

Pinned images:
  - alpine:latest -> alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
  - amazoncorretto:11-al2023-jdk -> amazoncorretto:11-al2023-jdk@sha256:ffd2c9bf16a8ffeaade21ade59c5d1d1865d770d47681e00613c626d023dbd54
  - ubuntu:lunar -> ubuntu:lunar@sha256:5a828e28de105c3d7821c4442f0f5d1c52dc16acf4999d5f31a3bc0f03f06edd

Generated by docker-image-pinner from plan-dev-4.csv.